### PR TITLE
Fix corrupted ZopfliOption values

### DIFF
--- a/libzopfli-sharp/Zopfli.cs
+++ b/libzopfli-sharp/Zopfli.cs
@@ -53,9 +53,9 @@ namespace LibZopfliSharp
 
                 // Compress the data via native methods
                 if (Environment.Is64BitProcess)
-                    ZopfliCompressor64.ZopfliCompress(ref options, type, data_in, data_in.Length, ref result, ref result_size);
+                    ZopfliCompressor64.ZopfliCompress(options, type, data_in, data_in.Length, ref result, ref result_size);
                 else
-                    ZopfliCompressor32.ZopfliCompress(ref options, type, data_in, data_in.Length, ref result, ref result_size);
+                    ZopfliCompressor32.ZopfliCompress(options, type, data_in, data_in.Length, ref result, ref result_size);
 
                 // Copy data back to managed memory and return
                 return NativeUtilities.GetDataFromUnmanagedMemory(result, (int)result_size);

--- a/libzopfli-sharp/ZopfliCompressor.cs
+++ b/libzopfli-sharp/ZopfliCompressor.cs
@@ -24,7 +24,7 @@ namespace LibZopfliSharp.Native
         /// <param name="data_out">Pointer to the dynamic output array to which the result is appended</param>
         /// <param name="data_out_size">This is the size of the memory block pointed to by the dynamic output array size</param>
         [DllImport("x86\\zopfli.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void ZopfliCompress(ref ZopfliOptions options, ZopfliFormat output_type, byte[] data, int data_size, ref IntPtr data_out, ref UIntPtr data_out_size);
+        public static extern void ZopfliCompress(ZopfliOptions options, ZopfliFormat output_type, byte[] data, int data_size, ref IntPtr data_out, ref UIntPtr data_out_size);
     }
 
     /// <summary>
@@ -42,6 +42,6 @@ namespace LibZopfliSharp.Native
         /// <param name="data_out">Pointer to the dynamic output array to which the result is appended</param>
         /// <param name="data_out_size">This is the size of the memory block pointed to by the dynamic output array size</param>
         [DllImport("amd64\\zopfli.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void ZopfliCompress(ref ZopfliOptions options, ZopfliFormat output_type, byte[] data, int data_size, ref IntPtr data_out, ref UIntPtr data_out_size);
+        public static extern void ZopfliCompress(ZopfliOptions options, ZopfliFormat output_type, byte[] data, int data_size, ref IntPtr data_out, ref UIntPtr data_out_size);
     }
 }


### PR DESCRIPTION
This fixes the incorrect marshaling of the C# ZopfliOption class. This would result in incorrect option values being referenced within the native ZopfliCompress function.

I believe this fixes @chylex's issue mentioned in #4.